### PR TITLE
Escaping support for JSON pointers

### DIFF
--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
@@ -83,6 +83,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 }
             }
 
+            if (sb.Length > 0)
+            {
+                strings.Add(sb.ToString());
+            }
+
             return strings.ToArray();
         }
     }

--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
@@ -4,9 +4,7 @@
 using Microsoft.AspNetCore.JsonPatch.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.JsonPatch.Internal
 {
@@ -43,8 +41,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         private static string[] ParsePath(string path)
         {
-            List<string> strings = new List<string>();
-            StringBuilder sb = new StringBuilder(path.Length);
+            var strings = new List<string>();
+            var sb = new StringBuilder(path.Length);
 
             for (int i = 0; i < path.Length; i++)
             {

--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/ParsedPath.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.JsonPatch.Internal
 {
@@ -12,6 +14,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         private readonly string[] _segments;
 
+        private static readonly Regex escapingRegex = new Regex("~(?<code>0|1)", RegexOptions.Compiled);
+
         public ParsedPath(string path)
         {
             if (path == null)
@@ -19,7 +23,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 throw new ArgumentNullException(nameof(path));
             }
 
-            _segments = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            _segments = path
+                .Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(segment => escapingRegex.Replace(segment, (match) => match.Groups["code"].Value == "0" ? "~" : "/"))
+                .ToArray();
         }
 
         public string LastSegment

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentJsonPropertyAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentJsonPropertyAttributeTest.cs
@@ -144,5 +144,23 @@ namespace Microsoft.AspNetCore.JsonPatch
             var pathToCheck = deserialized.Operations.First().path;
             Assert.Equal(pathToCheck, "/anothername");
         }
+
+        [Fact]
+        public void Add_OnApplyFromJson_EscapingHandledOnComplexJsonPropertyNameOnJsonDocument()
+        {
+            var doc = new JsonPropertyComplexNameDTO()
+            {
+                FooSlashBars = "InitialName"
+            };
+
+            // serialization should serialize to "AnotherName"
+            var serialized = "[{\"value\":\"Kevin\",\"path\":\"/foo~1bar~0\",\"op\":\"add\"}]";
+            var deserialized =
+                JsonConvert.DeserializeObject<JsonPatchDocument<JsonPropertyComplexNameDTO>>(serialized);
+
+            deserialized.ApplyTo(doc);
+
+            Assert.Equal("Kevin", doc.FooSlashBars);
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentJsonPropertyAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentJsonPropertyAttributeTest.cs
@@ -150,17 +150,22 @@ namespace Microsoft.AspNetCore.JsonPatch
         {
             var doc = new JsonPropertyComplexNameDTO()
             {
-                FooSlashBars = "InitialName"
+                FooSlashBars = "InitialName",
+                FooSlashTilde = new  SimpleDTO
+                {
+                    StringProperty  = "Initial Value"
+                }
             };
 
             // serialization should serialize to "AnotherName"
-            var serialized = "[{\"value\":\"Kevin\",\"path\":\"/foo~1bar~0\",\"op\":\"add\"}]";
+            var serialized = "[{\"value\":\"Kevin\",\"path\":\"/foo~1bar~0\",\"op\":\"add\"},{\"value\":\"Final Value\",\"path\":\"/foo~1~0/StringProperty\",\"op\":\"replace\"}]";
             var deserialized =
                 JsonConvert.DeserializeObject<JsonPatchDocument<JsonPropertyComplexNameDTO>>(serialized);
 
             deserialized.ApplyTo(doc);
 
             Assert.Equal("Kevin", doc.FooSlashBars);
+            Assert.Equal("Final Value", doc.FooSlashTilde.StringProperty);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPropertyComplexNameDTO.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPropertyComplexNameDTO.cs
@@ -9,5 +9,8 @@ namespace Microsoft.AspNetCore.JsonPatch
     {
         [JsonProperty("foo/bar~")]
         public string FooSlashBars { get; set; }
+
+        [JsonProperty("foo/~")]
+        public SimpleDTO FooSlashTilde { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPropertyComplexNameDTO.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPropertyComplexNameDTO.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.JsonPatch
+{
+    public class JsonPropertyComplexNameDTO
+    {
+        [JsonProperty("foo/bar~")]
+        public string FooSlashBars { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
@@ -1822,6 +1822,33 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
         }
 
         [Fact]
+        public void Replace_WhenDictionary_ValueAPocoType_WithEscaping_Succeeds()
+        {
+            // Arrange
+            var key1 = "Foo/Name";
+            var value1 = new Customer() { Name = "Jamesss" };
+            var key2 = "Foo";
+            var value2 = new Customer() { Name = "Mike" };
+            var model = new Class8();
+            model.DictionaryOfStringToCustomer[key1] = value1;
+            model.DictionaryOfStringToCustomer[key2] = value2;
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.Replace($"/DictionaryOfStringToCustomer/Foo~1Name/Name", "James");
+
+            // Act
+            patchDocument.ApplyTo(model);
+
+            // Assert
+            Assert.Equal(2, model.DictionaryOfStringToCustomer.Count);
+            var actualValue1 = model.DictionaryOfStringToCustomer[key1];
+            var actualValue2 = model.DictionaryOfStringToCustomer[key2];
+            Assert.NotNull(actualValue1);
+            Assert.Equal("James", actualValue1.Name);
+            Assert.Equal("Mike", actualValue2.Name);
+
+        }
+
+        [Fact]
         public void Replace_DeepNested_DictionaryValue_Succeeds()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/ParsedPathTests.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/ParsedPathTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.JsonPatch.Exceptions;
+using Microsoft.AspNetCore.JsonPatch.Internal;
+using Xunit;
+
+namespace Microsoft.AspNetCore.JsonPatch.Test
+{
+    public class ParsedPathTests
+    {
+        [Theory]
+        [InlineData("foo/bar~0baz", new string[] { "foo", "bar~baz" })]
+        [InlineData("foo/bar~00baz", new string[] { "foo", "bar~0baz" })]
+        [InlineData("foo/bar~01baz", new string[] { "foo", "bar~1baz" })]
+        [InlineData("foo/bar~10baz", new string[] { "foo", "bar/0baz" })]
+        [InlineData("foo/bar~1baz", new string[] { "foo", "bar/baz" })]
+        [InlineData("foo/bar~0/~0/~1~1/~0~0/baz", new string[] { "foo", "bar~", "~", "//", "~~", "baz" })]
+        [InlineData("~0~1foo", new string[] { "~/foo" })]
+        public void ParsingValidPathShouldSucceed(string path, string[] expected)
+        {
+            var parsedPath = new ParsedPath(path);
+            Assert.Equal(expected, parsedPath.Segments);
+        }
+
+        [Theory]
+        [InlineData("foo/bar~")]
+        [InlineData("~")]
+        [InlineData("~2")]
+        [InlineData("foo~3bar")]
+        public void PathWithInvalidEscapeSequenceShouldFail(string path)
+        {
+            Assert.Throws<JsonPatchException>(() =>
+            {
+                var parsedPath = new ParsedPath(path);
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Add Escaping support in ParsedPath class:
- Add Complex Name DTO requiring escaping
- Add Unit Test against that DTO

Addresses #44 
