### PR TITLE
Correct ListAdapter tests

### DIFF
--- a/test/Microsoft.AspNetCore.JsonPatch.Test/ListAdapterTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/ListAdapterTest.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var targetObject = (new List<int>() { 10, 20 }).AsReadOnly();
+            var targetObject = (new List<int>() { 10, 20 });
             var listAdapter = new ListAdapter();
             string message = null;
 
@@ -336,7 +336,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             // Arrange
             var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
-            var targetObject = (new List<int>() { 10, 20 }).AsReadOnly();
+            var targetObject = (new List<int>() { 10, 20 });
             var listAdapter = new ListAdapter();
             string message = null;
 


### PR DESCRIPTION
Modifying a ReadOnlyCollection will always fail