### PR TITLE
Throw JsonSerializationException from converters

### DIFF
--- a/src/Microsoft.AspNetCore.JsonPatch/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Converters/JsonPatchDocumentConverter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
             }
             catch (Exception ex)
             {
-                throw new JsonPatchException(Resources.FormatInvalidJsonPatchDocument(objectType.Name), ex);
+                throw new JsonSerializationException(Resources.FormatInvalidJsonPatchDocument(), ex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.JsonPatch/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Converters/JsonPatchDocumentConverter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
             }
             catch (Exception ex)
             {
-                throw new JsonSerializationException(Resources.FormatInvalidJsonPatchDocument(), ex);
+                throw new JsonSerializationException(Resources.InvalidJsonPatchDocument, ex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.AspNetCore.JsonPatch.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.Operations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -58,7 +57,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
             }
             catch (Exception ex)
             {
-                throw new JsonPatchException(Resources.FormatInvalidJsonPatchDocument(objectType.Name), ex);
+                throw new JsonSerializationException(Resources.FormatInvalidJsonPatchDocument(), ex);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Converters/TypedJsonPatchDocumentConverter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
             }
             catch (Exception ex)
             {
-                throw new JsonSerializationException(Resources.FormatInvalidJsonPatchDocument(), ex);
+                throw new JsonSerializationException(Resources.InvalidJsonPatchDocument, ex);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.JsonPatch/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Properties/Resources.Designer.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.JsonPatch
             => string.Format(CultureInfo.CurrentCulture, GetString("InvalidIndexValue"), p0);
 
         /// <summary>
-        /// The type '{0}' was malformed and could not be parsed.
+        /// The JsonPatchDocument was malformed and could not be parsed.
         /// </summary>
         internal static string InvalidJsonPatchDocument
         {
@@ -131,10 +131,10 @@ namespace Microsoft.AspNetCore.JsonPatch
         }
 
         /// <summary>
-        /// The type '{0}' was malformed and could not be parsed.
+        /// The JsonPatchDocument was malformed and could not be parsed.
         /// </summary>
-        internal static string FormatInvalidJsonPatchDocument(object p0)
-            => string.Format(CultureInfo.CurrentCulture, GetString("InvalidJsonPatchDocument"), p0);
+        internal static string FormatInvalidJsonPatchDocument()
+            => GetString("InvalidJsonPatchDocument");
 
         /// <summary>
         /// Invalid JsonPatch operation '{0}'.

--- a/src/Microsoft.AspNetCore.JsonPatch/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Properties/Resources.Designer.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.JsonPatch
             => string.Format(CultureInfo.CurrentCulture, GetString("InvalidIndexValue"), p0);
 
         /// <summary>
-        /// The JsonPatchDocument was malformed and could not be parsed.
+        /// The JSON patch document was malformed and could not be parsed.
         /// </summary>
         internal static string InvalidJsonPatchDocument
         {
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.JsonPatch
         }
 
         /// <summary>
-        /// The JsonPatchDocument was malformed and could not be parsed.
+        /// The JSON patch document was malformed and could not be parsed.
         /// </summary>
         internal static string FormatInvalidJsonPatchDocument()
             => GetString("InvalidJsonPatchDocument");

--- a/src/Microsoft.AspNetCore.JsonPatch/Resources.resx
+++ b/src/Microsoft.AspNetCore.JsonPatch/Resources.resx
@@ -142,7 +142,7 @@
     <value>The path segment '{0}' is invalid for an array index.</value>
   </data>
   <data name="InvalidJsonPatchDocument" xml:space="preserve">
-    <value>The JsonPatchDocument was malformed and could not be parsed.</value>
+    <value>The JSON patch document was malformed and could not be parsed.</value>
   </data>
   <data name="InvalidJsonPatchOperation" xml:space="preserve">
     <value>Invalid JsonPatch operation '{0}'.</value>

--- a/src/Microsoft.AspNetCore.JsonPatch/Resources.resx
+++ b/src/Microsoft.AspNetCore.JsonPatch/Resources.resx
@@ -142,7 +142,7 @@
     <value>The path segment '{0}' is invalid for an array index.</value>
   </data>
   <data name="InvalidJsonPatchDocument" xml:space="preserve">
-    <value>The type '{0}' was malformed and could not be parsed.</value>
+    <value>The JsonPatchDocument was malformed and could not be parsed.</value>
   </data>
   <data name="InvalidJsonPatchOperation" xml:space="preserve">
     <value>Invalid JsonPatch operation '{0}'.</value>

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
@@ -756,19 +756,35 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
         }
 
         [Fact]
+        public void DeserializationMustFailWithEnvelope_ForSimpleObject()
+        {
+            // Arrange
+            var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+
+            // Act & Assert
+            var exception = Assert.Throws<JsonSerializationException>(() =>
+            {
+                var deserialized
+                    = JsonConvert.DeserializeObject<JsonPatchDocument<SimpleObject>>(serialized);
+            });
+
+            Assert.Equal("The JsonPatchDocument was malformed and could not be parsed.", exception.Message);
+        }
+
+        [Fact]
         public void DeserializationMustFailWithEnvelope()
         {
             // Arrange
             var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
 
             // Act & Assert
-            var exception = Assert.Throws<JsonPatchException>(() =>
+            var exception = Assert.Throws<JsonSerializationException>(() =>
             {
                 var deserialized
-                    = JsonConvert.DeserializeObject<JsonPatchDocument<SimpleObject>>(serialized);
+                    = JsonConvert.DeserializeObject<JsonPatchDocument>(serialized);
             });
 
-            Assert.Equal("The type 'JsonPatchDocument`1' was malformed and could not be parsed.", exception.Message);
+            Assert.Equal("The JsonPatchDocument was malformed and could not be parsed.", exception.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/ObjectAdapterTests.cs
@@ -725,7 +725,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
         }
 
         [Fact]
-        public void DeserializationMustWorkWithoutEnvelope()
+        public void Deserialization_Successful_ForValidJsonPatchDocument()
         {
             // Arrange
             var doc = new SimpleObject()
@@ -756,23 +756,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
         }
 
         [Fact]
-        public void DeserializationMustFailWithEnvelope_ForSimpleObject()
-        {
-            // Arrange
-            var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
-
-            // Act & Assert
-            var exception = Assert.Throws<JsonSerializationException>(() =>
-            {
-                var deserialized
-                    = JsonConvert.DeserializeObject<JsonPatchDocument<SimpleObject>>(serialized);
-            });
-
-            Assert.Equal("The JsonPatchDocument was malformed and could not be parsed.", exception.Message);
-        }
-
-        [Fact]
-        public void DeserializationMustFailWithEnvelope()
+        public void Deserialization_Fails_ForInvalidJsonPatchDocument()
         {
             // Arrange
             var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
@@ -784,7 +768,23 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                     = JsonConvert.DeserializeObject<JsonPatchDocument>(serialized);
             });
 
-            Assert.Equal("The JsonPatchDocument was malformed and could not be parsed.", exception.Message);
+            Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
+        }
+
+        [Fact]
+        public void Deserialization_Fails_ForInvalidTypedJsonPatchDocument()
+        {
+            // Arrange
+            var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+
+            // Act & Assert
+            var exception = Assert.Throws<JsonSerializationException>(() =>
+            {
+                var deserialized
+                    = JsonConvert.DeserializeObject<JsonPatchDocument<SimpleObject>>(serialized);
+            });
+
+            Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
See https://github.com/aspnet/Entropy/pull/268

The converters need to send a JSON.NET exception and not a JsonPatchException so the MVC formatters can correctly propagate it.

cc @Eilon 