### PR TITLE
allow paths that contain '.'

### DIFF
--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/PathHelpers.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/PathHelpers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // absolutely necessary, but it allows us to already catch mistakes
             // on creation of the patch document rather than on execute.
 
-            if (path.Contains(".") || path.Contains("//") || path.Contains(" ") || path.Contains("\\"))
+            if (path.Contains("//") || path.Contains(" ") || path.Contains("\\"))
             {
                 throw new JsonPatchException(Resources.FormatInvalidValueForPath(path), null); 
             }

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/JsonPatchDocumentTest.cs
@@ -46,24 +46,6 @@ namespace Microsoft.AspNetCore.JsonPatch
         }
 
         [Fact]
-        public void InvalidPathWithDotShouldThrowException()
-        {
-            // Arrange
-            var patchDocument = new JsonPatchDocument();
-
-            // Act
-            var exception = Assert.Throws<JsonPatchException>(() =>
-            {
-                patchDocument.Add("NewInt.Test", 1);
-            });
-
-            // Assert
-            Assert.Equal(
-               "The provided string 'NewInt.Test' is an invalid path.",
-                exception.Message);
-        }
-
-        [Fact]
         public void NonGenericPatchDocToGenericMustSerialize()
         {
             // Arrange


### PR DESCRIPTION
fixes #124 

JSON Patch spec as found at jsonpatch.com never specifies that '.' character are invalid.  Several major REST APIs with HTTP Patch endpoints use paths that contain '.' characters.