### PR TITLE
Fix aspnet/AspNetCore#3559

### DIFF
--- a/src/Microsoft.AspNetCore.JsonPatch/Adapters/ObjectAdapter.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Adapters/ObjectAdapter.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
             if (TryGetValue(operation.from, objectToApplyTo, operation, out var propertyValue))
             {
                 // Create deep copy
-                var copyResult = ConversionResultProvider.CopyTo(propertyValue, propertyValue.GetType());
+                var copyResult = ConversionResultProvider.CopyTo(propertyValue, propertyValue?.GetType());
                 if (copyResult.CanBeConverted)
                 {
                     Add(operation.path,

--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/ConversionResultProvider.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/ConversionResultProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var targetType = typeToConvertTo;
             if (value == null)
             {
-                return new ConversionResult(IsNullableType(typeToConvertTo), null);
+                return new ConversionResult(true, null);
             }
             else if (typeToConvertTo.IsAssignableFrom(value.GetType()))
             {

--- a/src/Microsoft.AspNetCore.JsonPatch/Internal/ConversionResultProvider.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/Internal/ConversionResultProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var targetType = typeToConvertTo;
             if (value == null)
             {
-                return new ConversionResult(true, null);
+                return new ConversionResult(canBeConverted: true, convertedInstance: null);
             }
             else if (typeToConvertTo.IsAssignableFrom(value.GetType()))
             {

--- a/src/Microsoft.AspNetCore.JsonPatch/JsonPatchDocumentOfT.cs
+++ b/src/Microsoft.AspNetCore.JsonPatch/JsonPatchDocumentOfT.cs
@@ -503,7 +503,7 @@ namespace Microsoft.AspNetCore.JsonPatch
         }
 
         /// <summary>
-        /// Copy the value at specified location to the target location.  Willr esult in, for example:
+        /// Copy the value at specified location to the target location.  Will result in, for example:
         /// { "op": "copy", "from": "/a/b/c", "path": "/a/b/e" }
         /// </summary>
         /// <param name="from">source location</param>

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/ExpandoObjectIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/ExpandoObjectIntegrationTest.cs
@@ -160,6 +160,25 @@ namespace Microsoft.AspNetCore.JsonPatch.IntegrationTests
         }
 
         [Fact]
+        public void CopyNullStringProperty_ToAnotherStringProperty()
+        {
+            // Arrange
+            dynamic targetObject = new ExpandoObject();
+
+            targetObject.StringProperty = null;
+            targetObject.AnotherStringProperty = "B";
+
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.Copy("StringProperty", "AnotherStringProperty");
+
+            // Act
+            patchDocument.ApplyTo(targetObject);
+
+            // Assert
+            Assert.Null(targetObject.AnotherStringProperty);
+        }
+
+        [Fact]
         public void MoveIntegerValue_ToAnotherIntegerProperty()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/NestedObjectIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/NestedObjectIntegrationTest.cs
@@ -175,7 +175,30 @@ namespace Microsoft.AspNetCore.JsonPatch.IntegrationTests
 
             // Assert
             Assert.Equal("A", targetObject.SimpleObject.AnotherStringProperty);
-        }       
+        }
+
+        [Fact]
+        public void CopyNullStringProperty_ToAnotherStringProperty()
+        {
+            // Arrange
+            var targetObject = new SimpleObjectWithNestedObject()
+            {
+                SimpleObject = new SimpleObject()
+                {
+                    StringProperty = null,
+                    AnotherStringProperty = "B"
+                }
+            };
+
+            var patchDocument = new JsonPatchDocument<SimpleObjectWithNestedObject>();
+            patchDocument.Copy(o => o.SimpleObject.StringProperty, o => o.SimpleObject.AnotherStringProperty);
+
+            // Act
+            patchDocument.ApplyTo(targetObject);
+
+            // Assert
+            Assert.Null(targetObject.SimpleObject.AnotherStringProperty);
+        }
 
         [Fact]
         public void Copy_DeepClonesObject()

--- a/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/SimpleObjectIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.JsonPatch.Test/IntegrationTests/SimpleObjectIntegrationTest.cs
@@ -47,6 +47,26 @@ namespace Microsoft.AspNetCore.JsonPatch.IntegrationTests
         }
 
         [Fact]
+        public void CopyNullStringProperty_ToAnotherStringProperty()
+        {
+            // Arrange
+            var targetObject = new SimpleObject()
+            {
+                StringProperty = null,
+                AnotherStringProperty = "B"
+            };
+
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.Copy("StringProperty", "AnotherStringProperty");
+
+            // Act
+            patchDocument.ApplyTo(targetObject);
+
+            // Assert
+            Assert.Null(targetObject.AnotherStringProperty);
+        }
+
+        [Fact]
         public void MoveIntegerProperty_ToAnotherIntegerProperty()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/3559

Json Patch: System.NullReferenceException while trying to use copy operation from property with null value.

Note: Even if we are removing "IsNullableType" check which is not necessary in this place, we will proceed with this check later in ConversionResultProvider.ConvertTo#12 method.